### PR TITLE
Updates to CRUD methods

### DIFF
--- a/machines/push-data.js
+++ b/machines/push-data.js
@@ -15,11 +15,9 @@ module.exports = {
     child: {
       example: 'users',
       description: 'The child of your reference URL which you wish to write to.',
-      required: true
     },
     write: {
-      example: '{ "User 1": {"email": "user@gmail.com", "password": "password123"}}',
-      description: 'The dataset you wish to write to your Firebase instance, in JSON form.',
+      description: 'The dataset you wish to write to your Firebase instance.',
       typeclass: '*',
       required: true
     }
@@ -32,44 +30,38 @@ module.exports = {
     error: {
       description: 'An unexpected error occurred.'
     },
-    parseFailure: {
-      description: 'The data provided could not be parsed into a JSON Object.',
-      moreInfo: 'This usually happens due to a lack of double-quotes. You can check out exactly how to present your string of data here: http://www.json.org/'
-    },
+
     success: {
-      description: 'Firebase has written your data!'
+      example: "-JmahDOMzYCH1R_gGEAL",
+      description: "The unique key generated for the new data path."
     }
+
   },
 
   fn: function (inputs, exits) {
 
+    // Require the Firebase SDK
     var Firebase = require('firebase');
 
+    // Get the root reference
     var rootRef = new Firebase(inputs.firebaseURL);
 
-    var finalRef = rootRef.child(inputs.child);
+    // If a child path is specified, get a reference to that data path
+    var finalRef = inputs.child ? rootRef.child(inputs.child) : rootRef;
 
-    var jdata;
+    // Create a new data reference
+    var dataRef = finalRef.push(inputs.write, function(error) {
 
-    try {
-      jdata= JSON.parse(inputs.write);
-    }
-    catch (e){
-      return exits.parseFailure(e);
-    }
-
-
-    finalRef.push(jdata, function(error) {
+        // Handle errors
         if (error) {
-          return exits.error({
-            description: error
-          });
-        } else {
-          console.log("Firebase has logged the following data:", inputs.write);
-          return exits.success({
-            description: "Firebase has successfully logged your data."
-          });
+          return exits.error(error);
         }
+
+        // Get the unique ID of the new data path
+        var key = dataRef.key();
+
+        // Return it through the success exit
+        return exits.success(key);
       });
   },
 

--- a/machines/read-value.js
+++ b/machines/read-value.js
@@ -22,27 +22,30 @@ module.exports = {
       description: 'An unexpected error occurred.'
     },
     success: {
-      data: '{ "User 1": {"email": "user@gmail.com", "password": "password123"}}'
+      example: '{ "User 1": {"email": "user@gmail.com", "password": "password123"}}',
+      description: "The data at the specified path, as a JSON string."
     }
   },
 
   fn: function (inputs, exits) {
 
+    // Require the Firebase SDK
     var Firebase = require('firebase');
 
+    // Get the data path reference
     var ref = new Firebase(inputs.firebaseURL);
 
-    ref.on("value", function(snapshot) {
-        console.log(snapshot.val());
-        return exits.success({
-          data: snapshot.val()
-        });
-      }, function(errorObject) {
-          console.log("The Read operation failed: " + errorObject.code);
-          return exits.error({
-            description: "The Read operation failed: " + errorObject.code
-          });
-      });
+    // Attempt to read from the data path
+    ref.once("value", function(snapshot) {
+
+      // Return the data as a JSON string through the success exit
+      return exits.success(JSON.stringify(snapshot.val()));
+    },
+
+    // In case of error, send the error throuh the error exit
+    function(errorObject) {
+        return exits.error(errorObject);
+    });
 
   },
 

--- a/machines/remove-value.js
+++ b/machines/remove-value.js
@@ -1,0 +1,49 @@
+module.exports = {
+
+  friendlyName: 'Remove Value',
+
+  description: 'Remove data from a specific firebase location, such as "/users/".',
+
+  inputs: {
+    firebaseURL: {
+      example: 'your-firebase-database.firebaseio.com/users/',
+      description: 'The reference URL for your Firebase dataset.',
+      required: true
+    }
+  },
+
+  defaultExit: 'success',
+
+  exits: {
+
+    error: {
+      description: 'An unexpected error occurred.'
+    },
+    success: {
+      description: "The data was removed."
+    }
+  },
+
+  fn: function (inputs, exits) {
+
+    // Require the Firebase SDK
+    var Firebase = require('firebase');
+
+    // Get the data path reference
+    var ref = new Firebase(inputs.firebaseURL);
+
+    // Attempt to read from the data path
+    ref.remove(function(error) {
+
+      // Handle errors
+      if (error) {
+        return exits.error(error);
+      }
+
+      // Return through the success exit
+      return exits.success();
+    });
+
+  },
+
+};

--- a/machines/set-data.js
+++ b/machines/set-data.js
@@ -15,10 +15,8 @@ module.exports = {
     child: {
       example: 'users',
       description: 'The child of your reference URL which you wish to write to.',
-      required: true
     },
     write: {
-      example: '{ "User 1": {"email": "user@gmail.com", "password": "password123"}}',
       description: 'The dataset you wish to write to your Firebase instance, in JSON form.',
       typeclass: '*',
       required: true
@@ -32,10 +30,6 @@ module.exports = {
     error: {
       description: 'An unexpected error occurred.'
     },
-    parseFailure: {
-      description: 'The data provided could not be parsed into a JSON Object.',
-      moreInfo: 'This usually happens due to a lack of double-quotes. You can check out exactly how to present your string of data here: http://www.json.org/'
-    },
     success: {
       description: 'Firebase has written your data!'
     }
@@ -43,34 +37,26 @@ module.exports = {
 
   fn: function (inputs, exits) {
 
+    // Require the Firebase SDK
     var Firebase = require('firebase');
 
+    // Get the root reference
     var rootRef = new Firebase(inputs.firebaseURL);
 
-    var finalRef = rootRef.child(inputs.child);
+    // If a child path is specified, get a reference to that data path
+    var finalRef = inputs.child ? rootRef.child(inputs.child) : rootRef;
 
-    var jdata;
+    // Set the data at the path
+    finalRef.set(inputs.write, function(error) {
 
-    try {
-      jdata= JSON.parse(inputs.write);
-    }
-    catch (e){
-      return exits.parseFailure(e);
-    }
+      // Handle errors
+      if (error) {
+        return exits.error(error);
+      }
 
-
-    finalRef.set(jdata, function(error) {
-        if (error) {
-          return exits.error({
-            description: error
-          });
-        } else {
-          console.log("Firebase has logged the following data:", inputs.write);
-          return exits.success({
-            description: "Firebase has successfully logged your data."
-          });
-        }
-      });
-  },
+      // Return success
+      return exits.success();
+    });
+  }
 
 };

--- a/machines/update-data.js
+++ b/machines/update-data.js
@@ -15,12 +15,10 @@ module.exports = {
     child: {
       example: 'users',
       description: 'The child of your reference URL which you wish to write to.',
-      required: true
     },
     write: {
-      example: '{"email": "MyNewEmail@gmail.com"}',
-      description: 'The dataset you wish to write to the .',
-      typeclass: '*',
+      description: 'The children to overwrite in the data path.',
+      typeclass: 'dictionary',
       required: true
     }
   },
@@ -32,10 +30,6 @@ module.exports = {
     error: {
       description: 'An unexpected error occurred.'
     },
-    parseFailure: {
-      description: 'The data provided could not be parsed into a JSON Object.',
-      moreInfo: 'This usually happens due to a lack of double-quotes. You can check out exactly how to present your string of data here: http://www.json.org/'
-    },
     success: {
       description: 'Firebase has written your data!'
     }
@@ -43,34 +37,27 @@ module.exports = {
 
   fn: function (inputs, exits) {
 
+    // Require the Firebase SDK
     var Firebase = require('firebase');
 
+    // Get the root reference
     var rootRef = new Firebase(inputs.firebaseURL);
 
-    var finalRef = rootRef.child(inputs.child);
+    // If a child path is specified, get a reference to that data path
+    var finalRef = inputs.child ? rootRef.child(inputs.child) : rootRef;
 
-    var jdata;
+    // Set the data at the path
+    finalRef.update(inputs.write, function(error) {
 
-    try {
-      jdata= JSON.parse(inputs.write);
-    }
-    catch (e){
-      return exits.parseFailure(e);
-    }
+      // Handle errors
+      if (error) {
+        return exits.error(error);
+      }
 
+      // Return success
+      return exits.success();
+    });
 
-    finalRef.update(jdata, function(error) {
-        if (error) {
-          return exits.error({
-            description: error
-          });
-        } else {
-          console.log("Firebase has updated Child " + finalRef + " with the following data:", inputs.write);
-          return exits.success({
-            description: "Firebase has successfully updated your data."
-          });
-        }
-      });
   },
 
 };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
       "push-data",
       "update-data",
       "read-value",
+      "remove-value",
       "query-by-child_changed",
       "query-by-child_added",
       "query-by-child_removed",


### PR DESCRIPTION
This is looking great, just made a few tweaks to bring things up to spec.  Big thing to remember (which is not currently documented in the node-machine spec) is that `typeclass` and `example` are mutually exclusive for inputs--if you specify an example, then the typeclass will be ignored.  I fixed this for the "write" inputs of `Push Data`, `Set Data` and `Update Data`.  That allows the use of plain Javascript objects in those inputs, so parsing JSON in the machine is no longer necessary.  On the other side of things, I changed the "success" output example for `Read Value` to be a string.  Treeline doesn't allow for exits with unknown output schemas, so the solution is to output a string and then use the Parse JSON machine to convert it to an object.  Finally, I added a `Remove Value` machine to round out the CRUD operations.

I'd consider just removing the query machines--binding events doesn't really fit in with the philosophy of Machines (and especially Treeline), which is to make your code simple and easy to trace by guaranteeing that exits will only ever be called once.  Machines that bind events set up a situation where an exit can be called multiple times.  In this case, I fixed the `Read Value` machine to use `.once` instead of `.on`, and it looks like all of the query machines can be safely done away with because you can get the same functionality using `Read Value`.  But I'm not super familiar with Firebase so I may be misunderstanding something.  I've left it up to you.

Thanks for your work on this Nile!
